### PR TITLE
Tests, shutdown corrections, and memory re-use

### DIFF
--- a/src/lib/fracture/BocketPool.fs
+++ b/src/lib/fracture/BocketPool.fs
@@ -23,19 +23,17 @@ type internal BocketPool(name, number, size) =
         sw.Start()
         let res =x()
         sw.Stop()
-        if sw.ElapsedTicks > 500000L || pool.Count < 10  then
+        if sw.ElapsedTicks > 500000L then
             sprintf "Slow Bocket %s get: %fms, count: %d" name sw.Elapsed.TotalMilliseconds pool.Count |> Common.logger
         res 
 
     member this.Start(callback) =
-        let rec loop n =
-            if n < number then
-                let saea = new SocketAsyncEventArgs()
-                saea.Completed |> Observable.add callback
-                saea.SetBuffer(buffer, n, size)
-                this.CheckIn(saea)
-                loop (n + 1)
-        loop 0                    
+        for n in 0 .. number - 1 do
+            let saea = new SocketAsyncEventArgs()
+            saea.Completed |> Observable.add callback
+            saea.SetBuffer(buffer, n*size, size)
+            this.CheckIn(saea)
+
     member this.CheckOut() =
         time pool.Take
 

--- a/src/lib/fracture/BocketPool.fs
+++ b/src/lib/fracture/BocketPool.fs
@@ -16,6 +16,7 @@ type internal BocketPool(name, number, size) =
             while pool.Count > 1 do
                 pool.Take()
                     .Dispose()
+            pool.Dispose()
 
     let time x = 
         let sw = new System.Diagnostics.Stopwatch()
@@ -39,13 +40,15 @@ type internal BocketPool(name, number, size) =
         time pool.Take
 
     member this.CheckIn(saea) =
-        // ensure the the full range of the buffer is available this may have changed
-        // if the bocket was previously used for a send or connect operation
-        if saea.Count < size then 
-            saea.SetBuffer(saea.Offset, size)
-        pool.Add(saea)
+        if not disposed then
+            // ensure the the full range of the buffer is available this may have changed
+            // if the bocket was previously used for a send or connect operation
+            if saea.Count < size then 
+                saea.SetBuffer(saea.Offset, size)
+            pool.Add(saea)
 
     member this.Count =
         pool.Count
+
     interface IDisposable with
         member this.Dispose() = cleanUp()

--- a/src/lib/fracture/BocketPool.fs
+++ b/src/lib/fracture/BocketPool.fs
@@ -27,6 +27,15 @@ type internal BocketPool(name, number, size) =
             sprintf "Slow Bocket %s get: %fms, count: %d" name sw.Elapsed.TotalMilliseconds pool.Count |> Common.logger
         res 
 
+    let checkedOperation operation onFailure =
+        try 
+            operation()
+        with
+            | :? ArgumentNullException
+            | :? InvalidOperationException -> onFailure()
+
+    let raiseDisposed() = raise(ObjectDisposedException(name))
+
     member this.Start(callback) =
         for n in 0 .. number - 1 do
             let saea = new SocketAsyncEventArgs()
@@ -35,16 +44,23 @@ type internal BocketPool(name, number, size) =
             this.CheckIn(saea)
 
     member this.CheckOut() =
-        time pool.Take
+        if disposed then
+            raiseDisposed()
+        else
+            checkedOperation pool.Take raiseDisposed
 
     member this.CheckIn(saea) =
-        if not disposed then
+        if disposed then
+            // the pool is kicked; let's just dispose of it ourselves
+            saea.Dispose()
+        else 
             // ensure the the full range of the buffer is available this may have changed
             // if the bocket was previously used for a send or connect operation
             if saea.Count < size then 
                 saea.SetBuffer(saea.Offset, size)
-            pool.Add(saea)
-
+            // we might be trying to update the the pool when it's already been disposed 
+            checkedOperation (fun () -> pool.Add(saea)) saea.Dispose
+            
     member this.Count =
         pool.Count
 

--- a/src/lib/fracture/BocketPool.fs
+++ b/src/lib/fracture/BocketPool.fs
@@ -23,7 +23,7 @@ type internal BocketPool(name, number, size) =
         let res =x()
         sw.Stop()
         if sw.ElapsedTicks > 500000L || pool.Count < 10  then
-            Console.WriteLine(sprintf "Slow Bocket %s get: %fms, count: %d" name sw.Elapsed.TotalMilliseconds pool.Count)
+            sprintf "Slow Bocket %s get: %fms, count: %d" name sw.Elapsed.TotalMilliseconds pool.Count |> Common.logger
         res 
 
     member this.Start(callback) =

--- a/src/lib/fracture/BocketPool.fs
+++ b/src/lib/fracture/BocketPool.fs
@@ -4,10 +4,10 @@ open System.Net.Sockets
 open System.Collections.Generic
 open System.Collections.Concurrent
 
-type internal BocketPool(name, number, size) =
-    let totalsize = (number * size)
+type internal BocketPool(name, maxPoolCount, perBocketBufferSize) =
+    let totalsize = (maxPoolCount * perBocketBufferSize)
     let buffer = Array.zeroCreate<byte> totalsize
-    let pool = new BlockingCollection<SocketAsyncEventArgs>(number:int)
+    let pool = new BlockingCollection<SocketAsyncEventArgs>(maxPoolCount:int)
     let mutable disposed = false
     let cleanUp() = 
         if not disposed then
@@ -37,10 +37,10 @@ type internal BocketPool(name, number, size) =
     let raiseDisposed() = raise(ObjectDisposedException(name))
 
     member this.Start(callback) =
-        for n in 0 .. number - 1 do
+        for n in 0 .. maxPoolCount - 1 do
             let saea = new SocketAsyncEventArgs()
             saea.Completed |> Observable.add callback
-            saea.SetBuffer(buffer, n*size, size)
+            saea.SetBuffer(buffer, n*perBocketBufferSize, perBocketBufferSize)
             this.CheckIn(saea)
 
     member this.CheckOut() =
@@ -56,8 +56,8 @@ type internal BocketPool(name, number, size) =
         else 
             // ensure the the full range of the buffer is available this may have changed
             // if the bocket was previously used for a send or connect operation
-            if saea.Count < size then 
-                saea.SetBuffer(saea.Offset, size)
+            if saea.Count < perBocketBufferSize then 
+                saea.SetBuffer(saea.Offset, perBocketBufferSize)
             // we might be trying to update the the pool when it's already been disposed 
             checkedOperation (fun () -> pool.Add(saea)) saea.Dispose
             

--- a/src/lib/fracture/Common.fs
+++ b/src/lib/fracture/Common.fs
@@ -30,13 +30,12 @@ let disposeSocket (socket:Socket) =
         :? System.Net.Sockets.SocketException -> ()
     socket.Dispose()
 
-let send (client:Socket) completed (getSaea:unit -> SocketAsyncEventArgs)  (msg:byte[]) maxSize= 
+/// Sends data to the socket cached in the SAEA given, using the SAEA's buffer
+let send (client:Socket) completed (getSaea:unit -> SocketAsyncEventArgs) bufferLength (msg:byte[]) = 
     let rec loop offset =
         if offset < msg.Length then
-            let amountToSend =
-                let remaining = msg.Length - offset in
-                if remaining > maxSize then maxSize else remaining
             let saea = getSaea()
+            let amountToSend = min (msg.Length - offset) bufferLength
             saea.UserToken <- client
             Buffer.BlockCopy(msg, offset, saea.Buffer, saea.Offset, amountToSend)
             saea.SetBuffer(saea.Offset, amountToSend)

--- a/src/lib/fracture/Common.fs
+++ b/src/lib/fracture/Common.fs
@@ -17,6 +17,19 @@ let closeConnection (sock:Socket) =
     try sock.Shutdown(SocketShutdown.Both)
     finally sock.Close()
 
+let disposeSocket (socket:Socket) =
+    try
+        socket.Shutdown(SocketShutdown.Both)
+        socket.Disconnect(false)
+        socket.Close()
+    with
+        // note: the calls above can sometimes result in
+        // SocketException: A request to send or receive data was disallowed because the socket
+        // is not connected and (when sending on a datagram socket using a sendto call) no 
+        // address was supplied
+        :? System.Net.Sockets.SocketException -> ()
+    socket.Dispose()
+
 let send (client:Socket) completed (getSaea:unit -> SocketAsyncEventArgs)  (msg:byte[]) maxSize= 
     let rec loop offset =
         if offset < msg.Length then

--- a/src/lib/fracture/Common.fs
+++ b/src/lib/fracture/Common.fs
@@ -49,3 +49,6 @@ let acquireData(args:SocketAsyncEventArgs)=
     let data:byte[] = Array.zeroCreate args.BytesTransferred
     Buffer.BlockCopy(args.Buffer, args.Offset, data, 0, data.Length)
     data
+
+let remoteEndPointSafe(sock:Socket) =
+    try sock.RemoteEndPoint :?> System.Net.IPEndPoint with _ -> null

--- a/src/lib/fracture/Common.fs
+++ b/src/lib/fracture/Common.fs
@@ -4,6 +4,9 @@ open System
 open System.Net.Sockets
 open SocketExtensions
 
+/// Enables 3rd parties to inject their own logging framework for receiving errors
+let mutable logger : string->unit = fun message -> Console.Error.WriteLine(message)
+
 /// Creates a Socket and binds it to specified IPEndpoint, if you want a sytem assigned one Use IPEndPoint(IPAddress.Any, 0)
 let createSocket (ipEndPoint) =
     let socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp)
@@ -26,7 +29,7 @@ let send (client:Socket) completed (getSaea:unit -> SocketAsyncEventArgs)  (msg:
             saea.SetBuffer(saea.Offset, amountToSend)
             if client.Connected then client.SendAsyncSafe(completed, saea)
                                      loop (offset + amountToSend)
-            else Console.WriteLine(sprintf "Not connected to server")
+            else sprintf "Connection lost %A->%A" client.LocalEndPoint client.RemoteEndPoint |> logger
     loop 0  
     
 let acquireData(args:SocketAsyncEventArgs)= 

--- a/src/lib/fracture/Fracture.fsproj
+++ b/src/lib/fracture/Fracture.fsproj
@@ -36,10 +36,10 @@
   <Import Project="..\..\..\lib\FSharp\v4.0\bin\Microsoft.FSharp.Targets" />
   <ItemGroup>
     <None Include="packages.config" />
-    <Compile Include="Pipelets.fs" />
     <Compile Include="SocketExtensions.fs" />
-    <Compile Include="BocketPool.fs" />
     <Compile Include="Common.fs" />
+    <Compile Include="Pipelets.fs" />
+    <Compile Include="BocketPool.fs" />
     <Compile Include="Threading.fs" />
     <Compile Include="TcpClient.fs" />
     <Compile Include="TcpServer.fs" />

--- a/src/lib/fracture/Pipelets.fs
+++ b/src/lib/fracture/Pipelets.fs
@@ -39,7 +39,7 @@ type Pipelet<'a, 'b>(name:string, transform:'a -> 'b seq, router:'b seq -> 'b IP
                 with //force loop resume on error
                 | ex -> 
                     // TODO: Allow exceptional occurrences to be returned via other mechanisms than just printing to the console.
-                    printf "%A Error: %A" DateTime.Now.TimeOfDay ex.Message
+                    sprintf "%A Error: %A" DateTime.Now.TimeOfDay ex.Message |> Common.logger
                     return! loop routes
             | Attach(stage) -> return! loop (stage::routes)
             | Detach(stage) -> return! loop (List.filter (fun x -> x <> stage) routes)
@@ -50,7 +50,7 @@ type Pipelet<'a, 'b>(name:string, transform:'a -> 'b seq, router:'b seq -> 'b IP
         if ss.Wait(maxwait) then
             mailbox.Post(Payload data)
         // TODO: Allow exceptional occurrences to be returned via other mechanisms than just printing to the console.
-        else printf "%A Overflow: %A" DateTime.Now.TimeOfDay data //overflow
+        else sprintf "%A Overflow: %A" DateTime.Now.TimeOfDay data |> Common.logger //overflow
 
     /// Gets the name of the pipelet.
     member this.Name with get() = name

--- a/src/lib/fracture/TcpClient.fs
+++ b/src/lib/fracture/TcpClient.fs
@@ -21,9 +21,7 @@ type TcpClient(ipEndPoint, poolSize, size) =
     let cleanUp() = 
         if not disposed then
             disposed <- true
-            listeningSocket.Shutdown(SocketShutdown.Both)
-            listeningSocket.Disconnect(false)
-            listeningSocket.Close()
+            disposeSocket listeningSocket
             (pool :> IDisposable).Dispose()
 
     let connectedEvent = new Event<_>()

--- a/src/lib/fracture/TcpClient.fs
+++ b/src/lib/fracture/TcpClient.fs
@@ -61,7 +61,7 @@ type TcpClient(ipEndPoint, poolSize, size) =
             //start receive on accepted client
             let saea = pool.CheckOut()
             args.ConnectSocket.ReceiveAsyncSafe(completed, saea)
-        else args.SocketError.ToString() |> printfn "socket error on accept: %s"
+        else sprintf "socket error on accept: %A" args.SocketError |> Common.logger
 
     and processReceive (args:SocketAsyncEventArgs) =
         if args.SocketError = SocketError.Success && args.BytesTransferred > 0 then
@@ -88,7 +88,7 @@ type TcpClient(ipEndPoint, poolSize, size) =
         | SocketError.IOPending
         | SocketError.WouldBlock ->
             failwith "Buffer overflow or send buffer timeout" //graceful termination?  
-        | _ -> args.SocketError.ToString() |> printfn "socket error on send: %s"
+        | _ -> sprintf "socket error on send: %A" args.SocketError |> Common.logger
 
     ///This event is fired when a client connects.
     [<CLIEvent>]member this.Connected = connectedEvent.Publish

--- a/src/lib/fracture/TcpClient.fs
+++ b/src/lib/fracture/TcpClient.fs
@@ -98,7 +98,7 @@ type TcpClient(ipEndPoint, poolSize, size) =
     [<CLIEvent>]member this.Received = receivedEvent.Publish
 
     ///Sends the specified message to the client.
-    member this.Send(msg:byte[]) =
+    member this.Send(msg:ArraySegment<byte>) =
         if listeningSocket.Connected then
            send listeningSocket  completed  pool.CheckOut size  msg
         else listeningSocket.RemoteEndPoint :?> IPEndPoint |> disconnectedEvent.Trigger

--- a/src/lib/fracture/TcpClient.fs
+++ b/src/lib/fracture/TcpClient.fs
@@ -100,7 +100,7 @@ type TcpClient(ipEndPoint, poolSize, size) =
     ///Sends the specified message to the client.
     member this.Send(msg:byte[]) =
         if listeningSocket.Connected then
-           send listeningSocket  completed  pool.CheckOut  msg  size
+           send listeningSocket  completed  pool.CheckOut size  msg
         else listeningSocket.RemoteEndPoint :?> IPEndPoint |> disconnectedEvent.Trigger
         
     ///Starts connecting with remote server

--- a/src/lib/fracture/TcpServer.fs
+++ b/src/lib/fracture/TcpServer.fs
@@ -78,7 +78,7 @@ type TcpServer( poolSize, size, backlog, ?received, ?connected, ?disconnected, ?
             let receiveSaea = pool.CheckOut()
             receiveSaea.UserToken <- acceptSocket
             acceptSocket.ReceiveAsyncSafe(completed, receiveSaea)
-        else Console.WriteLine (sprintf "socket error on accept: %A" args.SocketError)
+        else sprintf "socket error on accept: %A" args.SocketError |> Common.logger
 
     and processDisconnect (args:SocketAsyncEventArgs) =
         args.UserToken :?> Socket |> disconnect
@@ -109,7 +109,7 @@ type TcpServer( poolSize, size, backlog, ?received, ?connected, ?disconnected, ?
         | SocketError.IOPending
         | SocketError.WouldBlock ->
             failwith "Buffer overflow or send buffer timeout" //graceful termination?  
-        | _ -> args.SocketError.ToString() |> printfn "socket error on send: %s"
+        | _ -> sprintf "socket error on send: %A" args.SocketError |> Common.logger
 
     static member Create(?received, ?connected, ?disconnected, ?sent) =
         new TcpServer(5000, 4096, 100, ?received = received, ?connected = connected, ?disconnected = disconnected, ?sent = sent)
@@ -119,7 +119,7 @@ type TcpServer( poolSize, size, backlog, ?received, ?connected, ?disconnected, ?
         let success, client = clients.TryGetValue(client)
         if success then 
             send client  completed  pool.CheckOut  msg  size
-        else failwith "could not find client %"
+        else failwith "could not find client %A" client.RemoteEndPoint
         
     ///Starts the accepting a incoming connections.
     member s.Listen(?address, ?port) =

--- a/src/lib/fracture/TcpServer.fs
+++ b/src/lib/fracture/TcpServer.fs
@@ -121,6 +121,7 @@ type TcpServer( poolSize, size, backlog, ?received, ?connected, ?disconnected, ?
         
     ///Starts the accepting a incoming connections.
     member s.Listen(?address, ?port) =
+        if listeningSocket <> null then invalidOp "this server was already started. it is listening on %A" listeningSocket.LocalEndPoint
         let address = defaultArg address "127.0.0.1"
         let port = defaultArg port 80
         //initialise the pools

--- a/src/lib/fracture/TcpServer.fs
+++ b/src/lib/fracture/TcpServer.fs
@@ -21,7 +21,7 @@ type TcpServer( poolSize, size, backlog, ?received, ?connected, ?disconnected, ?
         
     //ensures the listening socket is shutdown on disposal.
     let cleanUp(socket:Socket) = 
-        if not disposed then
+        if not disposed && socket <> null then
             disposed <- true
             socket.Shutdown(SocketShutdown.Both)
             socket.Disconnect(false)

--- a/src/lib/fracture/TcpServer.fs
+++ b/src/lib/fracture/TcpServer.fs
@@ -61,7 +61,7 @@ type TcpServer( poolSize, size, backlog, ?received, ?connected, ?disconnected, ?
             if args.BytesTransferred > 0 then
                 let data = acquireData args
                 //trigger received
-                received |> Option.iter (fun x -> x (data, acceptSocket.RemoteEndPoint :?> IPEndPoint, send acceptSocket completed pool.CheckOut) )
+                received |> Option.iter (fun x -> x (data, acceptSocket.RemoteEndPoint :?> IPEndPoint, send acceptSocket completed pool.CheckOut size) )
 
             //trigger connected
             connected |> Option.iter (fun x-> x(endPoint))
@@ -87,7 +87,7 @@ type TcpServer( poolSize, size, backlog, ?received, ?connected, ?disconnected, ?
             //process received data, check if data was given on connection.
             let data = acquireData args
             //trigger received
-            received |> Option.iter (fun x-> x (data, sock.RemoteEndPoint :?> IPEndPoint, send sock completed pool.CheckOut))
+            received |> Option.iter (fun x-> x (data, sock.RemoteEndPoint :?> IPEndPoint, send sock completed pool.CheckOut size))
             //get on with the next receive
             let saea = pool.CheckOut()
             saea.UserToken <- sock
@@ -116,7 +116,7 @@ type TcpServer( poolSize, size, backlog, ?received, ?connected, ?disconnected, ?
     member s.Send(client, msg:byte[]) =
         let success, client = clients.TryGetValue(client)
         if success then 
-            send client  completed  pool.CheckOut  msg  size
+            send client  completed  pool.CheckOut size  msg
         else failwith "could not find client %A" client.RemoteEndPoint
         
     ///Starts the accepting a incoming connections.

--- a/src/lib/fracture/TcpServer.fs
+++ b/src/lib/fracture/TcpServer.fs
@@ -23,9 +23,7 @@ type TcpServer( poolSize, size, backlog, ?received, ?connected, ?disconnected, ?
     let cleanUp(socket:Socket) = 
         if not disposed && socket <> null then
             disposed <- true
-            socket.Shutdown(SocketShutdown.Both)
-            socket.Disconnect(false)
-            socket.Close()
+            disposeSocket socket
             (pool :> IDisposable).Dispose()
             (connectionPool :> IDisposable).Dispose()
 

--- a/src/lib/fracture/TcpServer.fs
+++ b/src/lib/fracture/TcpServer.fs
@@ -132,7 +132,7 @@ type TcpServer( poolSize, perOperationBufferSize, acceptBacklogCount, ?received,
         new TcpServer(5000, 4096, 100, ?received = received, ?connected = connected, ?disconnected = disconnected, ?sent = sent)
 
     ///Sends the specified message to the client.
-    member s.Send(client, msg:byte[]) =
+    member s.Send(client, msg:ArraySegment<byte>) =
         let success, client = clients.TryGetValue(client)
         if success then 
             send client  completed  pool.CheckOut perOperationBufferSize  msg

--- a/src/lib/fracture/TcpServer.fs
+++ b/src/lib/fracture/TcpServer.fs
@@ -13,7 +13,7 @@ open Threading
 type TcpServer( poolSize, perOperationBufferSize, acceptBacklogCount, ?received, ?connected, ?disconnected, ?sent) =
 
     let pool = new BocketPool("regular pool", max poolSize 2, perOperationBufferSize)
-    let connectionPool = new BocketPool("connection pool", acceptBacklogCount, 288)(*288 bytes is the minimum size for a connection*)
+    let connectionPool = new BocketPool("connection pool", max acceptBacklogCount 2, 288)(*288 bytes is the minimum size for a connection*)
     let clients = new ConcurrentDictionary<_,_>()
     let mutable disposed = false
     let connections = ref 0

--- a/src/samples/TestClient/testclient.fs
+++ b/src/samples/TestClient/testclient.fs
@@ -14,17 +14,17 @@ let generateCircularSeq s =
 //                  |> generateCircularSeq 
 //                  |> Seq.take quoteSize 
 //                  |> Seq.toArray
-let testMessage = Array.init quoteSize (fun x -> 0uy)
+let testMessage = ArraySegment(Array.init quoteSize (fun x -> 0uy))
 
 let startClient(port, i) = async {
     do! Async.Sleep(i*50)
     Console.WriteLine(sprintf "Client %d" i )
     let client = new TcpClient()
-    client.Sent |> Observable.add (fun x -> Console.WriteLine( sprintf  "Sent: %A bytes" (fst x).Length) )
+    client.Sent |> Observable.add (fun x -> Console.WriteLine( sprintf  "Sent: %A bytes" (fst x).Count) )
 
     client.Received
     |> Observable.add (fun x ->
-        let res = sprintf "%A %A received: %i bytes" DateTime.Now.TimeOfDay (snd x) (fst x).Length 
+        let res = sprintf "%A %A received: %i bytes" DateTime.Now.TimeOfDay (snd x) (fst x).Count 
         Console.WriteLine(res ))
 
     client.Connected 

--- a/src/samples/TestServer/Program.fs
+++ b/src/samples/TestServer/Program.fs
@@ -12,7 +12,7 @@ try
     TcpServer.Create(
         disconnected = (fun ep -> Console.WriteLine(sprintf "%A %A: Disconnected" DateTime.Now.TimeOfDay ep)), 
         sent = (fun (received,ep) -> Console.WriteLine( sprintf  "%A Sent: %A " DateTime.Now.TimeOfDay received.Length )),
-        received = (fun (a,b,c) -> (c a a.Length))
+        received = (fun (data,ep,send) -> (send data))
         (*connected = fun(ep) -> ()*)
     ).Listen(port = 6667)
 

--- a/src/samples/TestServer/Program.fs
+++ b/src/samples/TestServer/Program.fs
@@ -11,7 +11,7 @@ System.AppDomain.CurrentDomain.UnhandledException |> Observable.add debug
 try
     TcpServer.Create(
         disconnected = (fun ep -> Console.WriteLine(sprintf "%A %A: Disconnected" DateTime.Now.TimeOfDay ep)), 
-        sent = (fun (received,ep) -> Console.WriteLine( sprintf  "%A Sent: %A " DateTime.Now.TimeOfDay received.Length )),
+        sent = (fun (received,ep) -> Console.WriteLine( sprintf  "%A Sent: %A " DateTime.Now.TimeOfDay received.Count )),
         received = (fun (data,ep,send) -> (send data))
         (*connected = fun(ep) -> ()*)
     ).Listen(port = 6667)

--- a/src/tests/Fracture.Tests/EchoServerTest.fs
+++ b/src/tests/Fracture.Tests/EchoServerTest.fs
@@ -26,6 +26,8 @@ let makeEchoServer(poolSize:int, perSocketBuffer:int, backlog:int) =
 
 let makeTestEchoServer() = makeEchoServer(4,1,2)
 
+let listen (server:TcpServer) = server.Listen(testEndPoint.Address.ToString(), testEndPoint.Port)
+
 let makeEchoClient endPoint poolSize size =
     let client = new TcpClient(endPoint, poolSize, size)
     client
@@ -47,7 +49,16 @@ let ``server listens when started and stops listening when stopped``() =
     let startAndStop() =
         shouldNotBeListening()
         use server = makeTestEchoServer()
-        server.Listen(testEndPoint.Address.ToString(), testEndPoint.Port)
+        server |> listen
         shouldBeListening()
     startAndStop()
     shouldNotBeListening()
+
+[<Test>]
+let ``server cannot be started twice``() =
+    shouldNotBeListening()
+    use server = makeTestEchoServer()
+    server |> listen
+    shouldBeListening()
+    (fun () -> server |> listen) |> should throw typeof<InvalidOperationException>
+    

--- a/src/tests/Fracture.Tests/EchoServerTest.fs
+++ b/src/tests/Fracture.Tests/EchoServerTest.fs
@@ -34,6 +34,7 @@ let makeEchoClient endPoint poolSize size =
 [<TestCase(4,1,2)>]
 let ``server starts and stop cleanly even if no one connects``(poolSize:int, perSocketBuffer:int, backlog:int) = 
     use server = makeEchoServer(poolSize, perSocketBuffer, backlog)
+    shouldNotBeListening()
     ()
 
 [<TestCase(1,1)>]
@@ -41,3 +42,12 @@ let ``client starts and stops cleanly even if it does not connect``(poolSize:int
     use client = makeEchoClient testEndPoint poolSize size
     ()
 
+[<Test>]
+let ``server listens when started and stops listening when stopped``() =
+    let startAndStop() =
+        shouldNotBeListening()
+        use server = makeTestEchoServer()
+        server.Listen(testEndPoint.Address.ToString(), testEndPoint.Port)
+        shouldBeListening()
+    startAndStop()
+    shouldNotBeListening()

--- a/src/tests/Fracture.Tests/EchoServerTest.fs
+++ b/src/tests/Fracture.Tests/EchoServerTest.fs
@@ -2,6 +2,7 @@
 
 open System
 open System.Net
+open System.Net.Sockets
 open Fracture
 open NUnit.Framework
 open FsUnit
@@ -13,8 +14,8 @@ let shouldBeListening() = isListeningTo testEndPoint |> should be True
 let shouldNotBeListening() = isListeningTo testEndPoint |> should be False
 
 let makeEchoServer(poolSize:int, perSocketBuffer:int, backlog:int) =
-    let received (data:byte[], client:IPEndPoint, echo:byte[]->int->unit) =
-        echo data 1
+    let received (data:byte[], client:IPEndPoint, echo:byte[]->unit) =
+        echo data
         
     let connected (client:IPEndPoint) = ()
     let disconnected (client:IPEndPoint) = ()
@@ -62,3 +63,20 @@ let ``server cannot be started twice``() =
     shouldBeListening()
     (fun () -> server |> listen) |> should throw typeof<InvalidOperationException>
     
+[<Test>]
+let ``echo server will echo data from naive socket call``([<Values(4,10,20)>]poolSize:int, [<Values(1,2,10,40)>]perSocketBuffer:int, [<Values(2)>]backlog:int, [<Values(1,2,4,8,32,64)>]messageLength:int) = 
+    // note we'll test the TcpServer using a simple naked socket to keep one foot on the ground.
+    // the client will disconnect after sending its message
+    use server = makeEchoServer(poolSize, perSocketBuffer, backlog)
+    server |> listen
+    use socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp)
+    socket.Connect(testEndPoint)
+    use stream = new NetworkStream(socket, true)
+    let message:byte[] = [| for i in 0 .. messageLength-1 -> byte(i % 256) |]
+    stream.Write(message, 0, message.Length)
+    let buffer:byte[] = Array.zeroCreate message.Length
+    let rec read i =
+        let bytes = stream.Read(buffer, i, message.Length - i)
+        if bytes + i < message.Length then read (i + bytes)
+    read 0
+    buffer |> should equal message

--- a/src/tests/Fracture.Tests/EchoServerTest.fs
+++ b/src/tests/Fracture.Tests/EchoServerTest.fs
@@ -83,11 +83,9 @@ let ``echo server will echo data from naive socket call``
      [<Values(1,5)>]           backlog:int,  // 2 is the minimum size for this backlog too, so this is testing that we adjust it properly
      [<Values(1,2,3,17,64)>]   messageLength:int,
      [<Values(0,1,7)>]         chunkSize:int) = // 0 chunk size means send the whole thing
-    shouldNotBeListening()
     let echoTest() =
         use server = makeEchoServer(poolSize, perSocketBuffer, backlog)
         server |> listen
-        shouldBeListening()
         use socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp)
         socket.Connect(testEndPoint)
         use stream = new NetworkStream(socket, true, WriteTimeout = 100, ReadTimeout = 100)
@@ -103,4 +101,3 @@ let ``echo server will echo data from naive socket call``
         read 0
         buffer |> should equal message
     echoTest()
-    shouldNotBeListening()

--- a/src/tests/Fracture.Tests/EchoServerTest.fs
+++ b/src/tests/Fracture.Tests/EchoServerTest.fs
@@ -1,0 +1,43 @@
+﻿module Fracture.Tests.EchoServerTest
+
+open System
+open System.Net
+open Fracture
+open NUnit.Framework
+open FsUnit
+
+let testEndPoint = IPEndPoint(IPAddress.Parse("127.0.0.1"), 81)
+let isListeningTo endPoint = System.Net.NetworkInformation.IPGlobalProperties.GetIPGlobalProperties().GetActiveTcpListeners() |> Seq.exists (fun ip -> ip = endPoint)
+
+let shouldBeListening() = isListeningTo testEndPoint |> should be True
+let shouldNotBeListening() = isListeningTo testEndPoint |> should be False
+
+let makeEchoServer(poolSize:int, perSocketBuffer:int, backlog:int) =
+    let received (data:byte[], client:IPEndPoint, echo:byte[]->int->unit) =
+        echo data 1
+        
+    let connected (client:IPEndPoint) = ()
+    let disconnected (client:IPEndPoint) = ()
+    let sent (data:byte[], client:IPEndPoint) = ()
+
+    let server = new TcpServer(poolSize, perSocketBuffer, backlog, received, connected, disconnected, sent)
+
+    server
+
+let makeTestEchoServer() = makeEchoServer(4,1,2)
+
+let makeEchoClient endPoint poolSize size =
+    let client = new TcpClient(endPoint, poolSize, size)
+    client
+
+
+[<TestCase(4,1,2)>]
+let ``server starts and stop cleanly even if no one connects``(poolSize:int, perSocketBuffer:int, backlog:int) = 
+    use server = makeEchoServer(poolSize, perSocketBuffer, backlog)
+    ()
+
+[<TestCase(1,1)>]
+let ``client starts and stops cleanly even if it does not connect``(poolSize:int, size:int) =
+    use client = makeEchoClient testEndPoint poolSize size
+    ()
+

--- a/src/tests/Fracture.Tests/EchoServerTest.fs
+++ b/src/tests/Fracture.Tests/EchoServerTest.fs
@@ -65,7 +65,7 @@ let ``server cannot be started twice``() =
     
 [<Test>]
 let ``echo server will echo data from naive socket call``
-    ([<Values(2,4,10)>]          poolSize:int, //note 2 appears to be the minimum pool size with our implementation for a single client
+    ([<Values(2,4,10)>]        poolSize:int, //note 2 appears to be the minimum pool size with our implementation for a single client
      [<Values(1,2,32,128)>]    perSocketBuffer:int, 
      [<Values(2)>]             backlog:int, 
      [<Values(1,2,64)>]        messageLength:int,

--- a/src/tests/Fracture.Tests/Fracture.Tests.fsproj
+++ b/src/tests/Fracture.Tests/Fracture.Tests.fsproj
@@ -34,6 +34,7 @@
   <ItemGroup>
     <None Include="packages.config" />
     <Compile Include="PipeletsTest.fs" />
+    <Compile Include="EchoServerTest.fs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FsUnit.NUnit-0.9.0">


### PR DESCRIPTION
I put in a  set of changes that mostly includes a few tests and some tweaks to ensure that server & client can shut down cleanly even if they haven't done anything.
I corrected what I _think_ are a few correctness errors (see 963dc1d, 3aa2a73)
Secondly, I made send & receive work with ArraySegment<byte>, potentially alleviating the need to copy data into buffers to pass it to clients, who are likely to copy it into whatever buffer they are working with anyway.
